### PR TITLE
Add Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - "node"
+  - "10"
   - "8.10"
   - "6.10"
 install:


### PR DESCRIPTION
As this is now LTS, add in preparation for AWS's official runtime release when it happens and potentially for custom Node 10 runtimes via new Layers functionality as well.